### PR TITLE
ES図の横向き表示対応

### DIFF
--- a/app/src/es_view/es_viewer.py
+++ b/app/src/es_view/es_viewer.py
@@ -77,7 +77,7 @@ class ESViewer:
         assert os.path.exists(f'/usr/share/fonts/truetype/{FONTNAME}')
         self.g = Graph(format='png')
         self.g.attr('graph', charset='UTF-8', fontname=FONTNAME, rankdir='LR')
-        self.g.attr('node', shape='note', color='azure4', fontname=FONTNAME)
+        self.g.attr('node', shape='none', color='azure4', fontname=FONTNAME)
         self.g.attr('edge', color='azure4', fontname=FONTNAME)
         self.es_data = es_data
         self.network = network

--- a/app/src/es_view/es_viewer.py
+++ b/app/src/es_view/es_viewer.py
@@ -31,6 +31,9 @@ def get_label(
         str
 
     '''
+    if company != company or company is None:
+        # company名が欠損のときは全体の値な気がする
+        company = '全体'
     if type(pop) is float and pop == pop:
         pop = int(pop)
     elif type(pop) is int:
@@ -73,7 +76,7 @@ class ESViewer:
     def __init__(self, es_data: DataFrame, network: [list]):
         assert os.path.exists(f'/usr/share/fonts/truetype/{FONTNAME}')
         self.g = Graph(format='png')
-        self.g.attr('graph', charset='UTF-8', fontname=FONTNAME)
+        self.g.attr('graph', charset='UTF-8', fontname=FONTNAME, rankdir='LR')
         self.g.attr('node', shape='note', color='azure4', fontname=FONTNAME)
         self.g.attr('edge', color='azure4', fontname=FONTNAME)
         self.es_data = es_data

--- a/app/src/es_view/es_viewer.py
+++ b/app/src/es_view/es_viewer.py
@@ -86,11 +86,7 @@ class ESViewer:
     def fit(self):
         '''nodeとedgeのセット
         '''
-        node_ids = []
-        for edge in self.network:
-            self.g.edge(edge[0], edge[1])
-            node_ids.extend(edge)
-        for _, r in self.es_data.iterrows():
+        for _, r in self.es_data.sort_values('id', ascending=False).iterrows():
             self.g.node(
                 r['id'],
                 style='filled',
@@ -99,6 +95,8 @@ class ESViewer:
                 label=get_label(r['属性名'], '不明', r['回答者数'],
                                 r['ES'], r['color'])
             )
+        for edge in self.network:
+            self.g.edge(edge[0], edge[1])
 
     def save(self, filename: str = None):
         '''画像を保存する


### PR DESCRIPTION
### Overview
close #11 


### 💻 Implementation details
**What you changed** 
* ES図の横向き表示対応
* company名が欠損のときは'全体'を返すようにした

**Expected behavior**
* ES図が横向きに表示されていること
* company名が欠損のときは'全体'を返すようになっている(具体的には，サンプルデータで回答者数が2549名のnodeのcampany名が'全体'となっていること)

**Other consideration**
## プルリクの確認方法

###  セットアップ

```sh
cd # ホームディレクトリに戻る
cd Github/ES_visualization # ES_visualizationフォルダまで移動
git checkout -b feature/Turnsideways # feature/Turnsidewaysブランチを作成し，そのブランチに移動
git pull origin feature/Turnsideways # リモートのfeature/Turnsidewaysブランチからコードを引っ張ってくる
make run # dockerコンテナを立ち上げる
```

### UIで確認
 
dockerコンテナを立ち上がったら以下のURL確認

http://localhost

「ファイルを選択」から2ファイルを選択し「submit」する

表示される画像を確認する

* 補足

cd コマンド -> 指定したディレクトリに移動する
git コマンド

```sh
git branch # いまローカルにあるブランチを確認
git checkout ブランチ名 # ローカルにあるブランチに移動する
git checkout -b ブランチ名 # ローカルのそのブランチがない場合，作成しながら移動する
git pull origin リモートブランチ名 # リモート(Github上)にあるブランチからコードを引っ張ってくる
```